### PR TITLE
Change pa-rofi search to be case-insensitive

### DIFF
--- a/contrib/pa-rofi
+++ b/contrib/pa-rofi
@@ -2,7 +2,7 @@
 
 cd "${PA_DIR:-$HOME/.local/share/pa}"
 password_files="$(find * -type f | grep -v '/.git')"
-password=$(printf '%s\n' "$password_files" | sed 's/.age//' | rofi -dmenu "$@")
+password=$(printf '%s\n' "$password_files" | sed 's/.age//' | rofi -dmenu -i "$@")
 
 pa show "$password" | head -n 1 |
     xdotool type --clearmodifiers --file -


### PR DESCRIPTION
The title is pretty self-explanatory.

Of course, changing the default to be case-insensitive is a personal preference but I imagine most people prefer it like this.