### PR TITLE
Create nested tmp directories in pw_edit

### DIFF
--- a/pa
+++ b/pa
@@ -60,7 +60,7 @@ pw_edit() {
     # residual badness
     [ -d /dev/shm ] || die "Failed to access /dev/shm"
 
-    mkdir -p /dev/shm/pa
+    mkdir -p "/dev/shm/pa/${name%/*}"
     trap 'rm -rf /dev/shm/pa' EXIT
     tmpfile="/dev/shm/pa/$name.txt"
 


### PR DESCRIPTION
Writing to the tmp file in pw_edit would fail if you have a nested password.
E.g. `pa edit path/to/password` would fail because `path/to` directories don't exist in `/dev/shm/pa/`