### PR TITLE
Quote variable inside trap handler

### DIFF
--- a/pa
+++ b/pa
@@ -63,7 +63,7 @@ pw_edit() {
     mkdir "$editdir" ||
         die "Couldn't create shared memory dir"
 
-    trap 'rm -rf $editdir' EXIT
+    trap 'rm -rf "$editdir"' EXIT
 
     # Handle nested items (/foo/bar.age)
     mkdir -p "$(dirname "$tmpfile")"


### PR DESCRIPTION
It's not strictly required, as `$editdir` shouldn't contain any special characters, but better to be safe in case this changes in the future. Also, you do quote `$editdir` in the `mkdir` call, so quoting it inside the trap handler as well is more consistent.