### PR TITLE
fix delete for password names that start with a hyphen

### DIFF
--- a/pa
+++ b/pa
@@ -79,12 +79,12 @@ pw_edit() {
 
 pw_del() {
     yn "Delete pass file '$1'?" && {
-        rm -f "$1.age"
+        rm -f "./$1.age"
 
         # Remove empty parent directories of a password
         # entry. It's fine if this fails as it means that
         # another entry also lives in the same directory.
-        rmdir -p "${1%/*}" 2>/dev/null || :
+        rmdir -p "./${1%/*}" 2>/dev/null || :
     }
 }
 


### PR DESCRIPTION
This PR fixes `pa d` for passwords that have a name starting with `--`. See:

```
user:~$ pa a --help
Generate a password? [y/n]: y
Saved '--help' to the store.
`user:~$  pa d --help
Delete pass file '--help'? [y/n]: y
rm: unrecognized option '--help.age'
Try 'rm ./--help.age' to remove the file '--help.age'.
Try 'rm --help' for more information.
```

Thanks for the tool, its really awesome!

Greetings,
Rafa