### PR TITLE
use 'openssl rand' as a fallback CSPRNG

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@
     - multiple identity/recipient support
     - written in portable posix shell
     - simple to extend
-    - only ~160 lines of code
+    - only ~170 lines of code
     - pronounced "pah" - as in "papa"
 
 

--- a/pa
+++ b/pa
@@ -105,9 +105,11 @@ git_add_and_commit() {
 }
 
 rand_chars() {
-    # Generate random characters by reading '/dev/urandom' with the
+    # Generate random characters by reading from CSPRNG with the
     # 'tr' command to translate the random bytes into a
     # configurable character set.
+    #
+    # Uses '/dev/urandom' if available and 'openssl rand' otherwise.
     #
     # The 'dd' command is then used to read only the desired
     # password length, since head -c isn't POSIX compliant.
@@ -117,9 +119,20 @@ rand_chars() {
     #
     # $1 = number of chars to receive
     # $2 = filter for the chars
-    #
-    # TODO: add more safety/compat here in case /dev/urandom doesn't exist
-    LC_ALL=C tr -dc "$2" </dev/urandom | dd ibs=1 obs=1 count="$1" 2>/dev/null
+    LC_ALL=C
+
+    if [ -r /dev/urandom ]; then
+        tr -dc "$2" </dev/urandom | dd ibs=1 obs=1 count="$1" 2>/dev/null
+    else
+        while [ "${#chars}" -lt "$1" ]; do
+                # 512 bytes should be enough to generate a password
+                # with the default length and pattern on first try.
+                chars="$chars$(openssl rand 512 | tr -dc "$2")"
+        done
+        dd ibs=1 obs=1 count="$1" 2>/dev/null <<-EOF
+			$chars
+		EOF
+    fi
 }
 
 yn() {


### PR DESCRIPTION
I decided to look into this one TODO comment, and after a bit of investigating, I found just one candidate of CSPRNG that could be available for use in a shell script if /dev/urandom fails, which is `openssl rand`.

now, I don't actually think this should be merged. first of all, the environment where `openssl rand` is available, but /dev/urandom is not, excludes almost any normally working current Unix-like desktop (which is what pa targets). in fact, I could only find Plan 9/9front in that category which doesn't have /dev/urandom, but it also wouldn't have openssl installed either, which discards this solution. it also can't simply fallback to /dev/random here either, because e.g. Plan 9's /dev/random is [extremely slow](https://9p.io/magic/man2html/3/cons) and probably should not be used in pa (in general I guess it's just not possible to rely on a random device in systems which don't provide /dev/urandom):
>The numbers are generated by a low priority kernel process that loops incrementing a variable. Each clock tick the variable is sampled and, if it has changed sufficiently, the last few bits are appended to a buffer. This process is inefficient at best producing at most a few hundred bits a second. Therefore, random should be treated as a seed to pseudo–random number generators which can produce a faster rate stream.

it would also be weird to explain that "`openssl rand` is an optional dependency, but not really, because it will never be called for practically everyone, that's just here as a theoretical fallback" (I felt insane just typing that out).

unless I'm missing a utility that's not `openssl rand` which could be used from shell and could be more ubiquitous on Unix-like systems than /dev/urandom, IMO it's safe to drop that TODO and just keep using /dev/urandom, until some upset experienced Plan 9 user offers a sane solution for their OS.