### PR TITLE
fall back to rage if age is unavailable

### DIFF
--- a/contrib/pa-pass
+++ b/contrib/pa-pass
@@ -12,9 +12,11 @@ basedir="${XDG_DATA_HOME:=$HOME/.local/share}/pa"
 # Create pa store if it doesn't exist.
 pa list >/dev/null
 
+age=$(command -v age || command -v rage)
+
 find "$PASSWORD_STORE_DIR" -name '*.gpg' | while read -r passfile; do
     name="$(printf '%s\n' "${passfile#"$PASSWORD_STORE_DIR/"}" | sed 's/\.gpg$//')"
     mkdir -p "$PA_DIR/$(dirname "$name")"
-    gpg2 -d "$passfile" | age -R "$basedir/recipients" -o "$PA_DIR/$name.age"
+    gpg2 -d "$passfile" | $age -R "$basedir/recipients" -o "$PA_DIR/$name.age"
     printf '%s\n' "Saved '$name' to the store."
 done

--- a/contrib/pa-rekey
+++ b/contrib/pa-rekey
@@ -14,13 +14,19 @@ umask 077
 [ "$PA_IDENTITIES" ] && cp "$PA_IDENTITIES" "$basedir/identities.tmp"
 [ "$PA_RECIPIENTS" ] && cp "$PA_RECIPIENTS" "$basedir/recipients.tmp"
 
-age-keygen >>"$basedir/identities.tmp" 2>/dev/null
-age-keygen -y "$basedir/identities.tmp" >>"$basedir/recipients.tmp" 2>/dev/null
+if age_keygen=$(command -v age-keygen || command -v rage-keygen); then
+    $age_keygen >>"$basedir/identities.tmp" 2>/dev/null &&
+    $age_keygen -y "$basedir/identities.tmp" >>"$basedir/recipients.tmp" 2>/dev/null
+fi
+
+age=$(command -v age || command -v rage)
 
 pa list | while read -r name; do
-    pa show "$name" | age -R "$basedir/recipients.tmp" -o "$PA_DIR/$name.tmp.age"
+    pa show "$name" | $age -R "$basedir/recipients.tmp" -o "$PA_DIR/$name.tmp.age"
     mv "$PA_DIR/$name.tmp.age" "$PA_DIR/$name.age"
 done
 
-mv "$basedir/identities.tmp" "$basedir/identities"
-mv "$basedir/recipients.tmp" "$basedir/recipients"
+if [ "$age_keygen" ]; then
+    mv "$basedir/identities.tmp" "$basedir/identities"
+    mv "$basedir/recipients.tmp" "$basedir/recipients"
+fi

--- a/pa
+++ b/pa
@@ -34,7 +34,7 @@ pw_add() {
     # Heredocs are sometimes implemented via temporary files,
     # however this is typically done using 'mkstemp()' which
     # is more secure than a leak in '/proc'.
-    age --encrypt -R "$recipients_file" -o "./$name.age" <<-EOF ||
+    $age --encrypt -R "$recipients_file" -o "./$name.age" <<-EOF ||
 		$pass
 	EOF
         die "Couldn't encrypt $name.age"
@@ -70,12 +70,12 @@ pw_edit() {
 
     trap 'rm -rf "$editdir"' EXIT
 
-    age --decrypt -i "$identities_file" -o "$tmpfile" "./$name.age" ||
+    $age --decrypt -i "$identities_file" -o "$tmpfile" "./$name.age" ||
         die "Couldn't decrypt $name.age"
 
     "${EDITOR:-vi}" "$tmpfile"
 
-    age --encrypt -R "$recipients_file" -o "./$name.age" "$tmpfile" ||
+    $age --encrypt -R "$recipients_file" -o "./$name.age" "$tmpfile" ||
         die "Couldn't encrypt $name.age"
 
     git_add_and_commit "./$name.age" "edit '$name'"
@@ -95,7 +95,7 @@ pw_del() {
 }
 
 pw_show() {
-    age --decrypt -i "$identities_file" "./$1.age" ||
+    $age --decrypt -i "$identities_file" "./$1.age" ||
         die "Couldn't decrypt $1.age"
 }
 
@@ -200,11 +200,11 @@ usage() {
 }
 
 main() {
-    command -v age >/dev/null 2>&1 ||
-        die "age not found, install per https://github.com/FiloSottile/age"
+    age=$(command -v age || command -v rage) ||
+        die "age not found, install per https://age-encryption.org"
 
-    command -v age-keygen >/dev/null 2>&1 ||
-        die "age-keygen not found, install per https://github.com/FiloSottile/age"
+    age_keygen=$(command -v age-keygen || command -v rage-keygen) ||
+        die "age-keygen not found, install per https://age-encryption.org"
 
     basedir="${XDG_DATA_HOME:=$HOME/.local/share}/pa"
     : "${PA_DIR:=$basedir/passwords}"
@@ -242,7 +242,7 @@ main() {
         # Configure diff driver for age encrypted files that treats them as
         # binary and decrypts them when a human-readable diff is requested.
         git config diff.age.binary true
-        git config diff.age.textconv "age --decrypt -i \"$identities_file\""
+        git config diff.age.textconv "$age --decrypt -i \"$identities_file\""
 
         # Assign this diff driver to all passwords.
         printf '%s\n' '*.age diff=age' >.gitattributes
@@ -274,10 +274,10 @@ main() {
     # Then, attempt key generation.
     [ -f "$identities_file" ] ||
         cp ~/.age/key.txt "$identities_file" 2>/dev/null ||
-        age-keygen -o "$identities_file" 2>/dev/null
+        $age_keygen -o "$identities_file" 2>/dev/null
 
     [ -f "$recipients_file" ] ||
-        age-keygen -y -o "$recipients_file" "$identities_file" 2>/dev/null
+        $age_keygen -y -o "$recipients_file" "$identities_file" 2>/dev/null
 
     # Ensure that we leave the terminal in a usable state on Ctrl+C.
     [ -t 1 ] && trap 'stty echo icanon; trap - INT; kill -s INT 0' INT


### PR DESCRIPTION
I've tested pa with rage and it does indeed work without issues just by changing the binary name, so maybe there's no reason to limit the options. I'd leave it as an undocumented option though, age would still be recommended as a reference implementation with a more active development (and it's still faster AFAIU - str4d/rage#57). Passage [provides](https://github.com/FiloSottile/passage/blob/main/src/password-store.sh#L9) `PASSAGE_AGE` option to change the binary name, but I think that solution is worse: in addition to being a redundant configuration option that can just be inferred from what's installed, [age spec](https://age-encryption.org/v1) doesn't specify API for CLIs, so there's no guarantee that any CLI that's going to implement age protocol is going to be interoperable in terms of interface with age(1) the way rage is.