### PR TITLE
improve wordings

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@
 
   usage
     pa
-      a simple password manager based on age
+      a simple password manager
 
     commands:
       [a]dd  [name] - Add a password entry.
@@ -31,7 +31,7 @@
 
     env vars:
       Password length:   export PA_LENGTH=50
-      Password pattern:  export PA_PATTERN=_A-Z-a-z-0-9
+      Password pattern:  export PA_PATTERN=A-Za-z0-9-_
       Password dir:      export PA_DIR=~/.local/share/pa/passwords
       Disable tracking:  export PA_NOGIT=
 
@@ -51,7 +51,7 @@
     <opens $EDITOR or vi>
 
     $ pa del test
-    Delete pass file 'test'? [y/N]: y
+    Delete password 'test'? [y/N]: y
 
 
   faq

--- a/pa
+++ b/pa
@@ -1,30 +1,30 @@
 #!/bin/sh
 #
-# pa - a simple password manager based on age
+# pa - a simple password manager
 
 pw_add() {
     name=$1
 
     if yn "Generate a password?"; then
-        pass=$(rand_chars "${PA_LENGTH:-50}" "${PA_PATTERN:-_A-Z-a-z-0-9}")
+        pass=$(rand_chars "${PA_LENGTH:-50}" "${PA_PATTERN:-A-Za-z0-9-_}")
 
         [ "$pass" ] ||
             die "Couldn't generate a password"
     else
         # 'sread()' is a simple wrapper function around 'read'
         # to prevent user input from being printed to the terminal.
-        sread pass "Enter password"
+        sread pass "Enter a password"
 
         [ "$pass" ] ||
             die "Password can't be empty"
 
-        sread pass2 "Enter password (again)"
+        sread pass2 "Enter a password (again)"
 
         # Disable this check as we dynamically populate the two
         # passwords using the 'sread()' function.
         # shellcheck disable=2154
         [ "$pass" = "$pass2" ] ||
-            die "Passwords do not match"
+            die "Passwords don't match"
     fi
 
     mkdir -p "$(dirname "./$name")" ||
@@ -70,7 +70,7 @@ pw_edit() {
 
     # Handle nested items (/foo/bar.age)
     mkdir -p "$(dirname "$tmpfile")" ||
-        die "Couldn't create shared memory dir"
+        die "Couldn't create a shared memory dir"
 
     trap 'rm -rf "$editdir"' EXIT
 
@@ -86,7 +86,7 @@ pw_edit() {
 }
 
 pw_del() {
-    yn "Delete pass file '$1'?" && {
+    yn "Delete password '$1'?" && {
         rm -f "./$1.age"
 
         # Remove empty parent directories of a password
@@ -185,7 +185,7 @@ die() {
 usage() {
     printf %s "\
   pa
-    a simple password manager based on age
+    a simple password manager
 
   commands:
     [a]dd  [name] - Add a password entry.
@@ -196,7 +196,7 @@ usage() {
 
   env vars:
     Password length:   export PA_LENGTH=50
-    Password pattern:  export PA_PATTERN=_A-Z-a-z-0-9
+    Password pattern:  export PA_PATTERN=A-Za-z0-9-_
     Password dir:      export PA_DIR=~/.local/share/pa/passwords
     Disable tracking:  export PA_NOGIT=
 "


### PR DESCRIPTION
1. remove 'based on age', because it's not added anywhere else except the usage message, and it seems to confuse folks who may think that this is about age as in dictionary instead of age as encryption tool
2. remove duplicate dashes from the default pattern and put special characters at the end (just makes more sense for me personally)
3. reword 'pass file' -> 'password', because in that context it's not actually a file (the file would be `$name.age`), and the new wording is consistent with glob guards
4. use contraction in a single instance where it's not used yet
5. sprinkle articles where it felt right - but please note that I'm ESL so I may not be gramatically correct everywhere, so LMK if I made any mistakes