### PR TITLE
generate new password if it doesn't exist in menu scripts

### DIFF
--- a/contrib/pa-bemenu
+++ b/contrib/pa-bemenu
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
 # prompt for a password via bemenu
+# generate new password if it doesn't exist
 # then type the selected password via wtype
 
 name=$(pa list | bemenu -c -W 0.2 -l 20 "$@")
-pa show "$name" | head -n 1 | tr -d '\n' | wtype -
+{ pa show "$name" || { printf y | pa add "$name" >/dev/null && pa show "$name"; }; } |
+    head -n 1 | tr -d '\n' | wtype -

--- a/contrib/pa-dmenu
+++ b/contrib/pa-dmenu
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
 # prompt for a password via dmenu
+# generate new password if it doesn't exist
 # then type the selected password via xdotool
 
 name=$(pa list | dmenu "$@")
-pa show "$name" | head -n 1 | tr -d '\n' | xdotool type --clearmodifiers --file -
+{ pa show "$name" || { printf y | pa add "$name" >/dev/null && pa show "$name"; }; } |
+    head -n 1 | tr -d '\n' | xdotool type --clearmodifiers --file -

--- a/contrib/pa-fuzzel
+++ b/contrib/pa-fuzzel
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
 # prompt for a password via fuzzel
+# generate new password if it doesn't exist
 # then type the selected password via wtype
 
 name=$(pa list | fuzzel -dmenu "$@")
-pa show "$name" | head -n 1 | tr -d '\n' | wtype -
+{ pa show "$name" || { printf y | pa add "$name" >/dev/null && pa show "$name"; }; } |
+    head -n 1 | tr -d '\n' | wtype -

--- a/contrib/pa-rofi
+++ b/contrib/pa-rofi
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
 # prompt for a password via rofi
+# generate new password if it doesn't exist
 # then type the selected password via xdotool
 
 name=$(pa list | rofi -dmenu -i "$@")
-pa show "$name" | head -n 1 | tr -d '\n' | xdotool type --clearmodifiers --file -
+{ pa show "$name" || { printf y | pa add "$name" >/dev/null && pa show "$name"; }; } |
+    head -n 1 | tr -d '\n' | xdotool type --clearmodifiers --file -

--- a/contrib/pa-wmenu
+++ b/contrib/pa-wmenu
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
 # prompt for a password via wmenu
+# generate new password if it doesn't exist
 # then type the selected password via wtype
 
 name=$(pa list | wmenu "$@")
-pa show "$name" | head -n 1 | tr -d '\n' | wtype -
+{ pa show "$name" || { printf y | pa add "$name" >/dev/null && pa show "$name"; }; } |
+    head -n 1 | tr -d '\n' | wtype -


### PR DESCRIPTION
this complicates them a bit, but I think it's worth it, because it would allow to never open a terminal for pa (except for deletion, but it can be trivially handled separately with `printf y | pa del "$(pa list | wmenu)"` if needed), and I think this behaviour makes sense UX-wise