### PR TITLE
add pa-urn

### DIFF
--- a/contrib/pa-urn
+++ b/contrib/pa-urn
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+usage() {
+    printf %s "\
+  pa-urn
+
+  commands:
+    [c]lose [file] - Archive password store into file.
+    [o]pen  [file] - Extract file into password store.
+"
+}
+
+create_tar() {
+    if command -v pax >/dev/null 2>&1; then
+        pax -x ustar -w "./$1"
+    else
+        tar c "./$1"
+    fi
+}
+
+extract_tar() {
+    if command -v pax >/dev/null 2>&1; then
+        pax -r
+    else
+        tar x
+    fi
+}
+
+die() {
+    printf 'error: %s.\n' "$1" >&2
+    exit 1
+}
+
+set -o pipefail
+
+age=$(command -v age || command -v rage) ||
+    die "age not found, install per https://age-encryption.org"
+
+basedir=${XDG_DATA_HOME:=$HOME/.local/share}/pa
+: "${PA_DIR:=$basedir/passwords}"
+
+dir=$(realpath "$PA_DIR") ||
+    die "Couldn't get path to password directory"
+
+name=$(basename "$dir")
+if [ "$2" ]; then
+    urn=$(realpath -- "$2") ||
+        die "Couldn't get path to file '$2'"
+else
+    urn=$(pwd)/$name.tar.age ||
+        die "Couldn't get working directory"
+fi
+
+cd "$(dirname "$dir")" ||
+    die "Couldn't change to parent of password directory"
+
+case $1 in
+c*)
+    { create_tar "$name" | $age -R "$basedir/recipients" -o "$urn"; } &&
+        printf '%s\n' "Store has been archived into $urn"
+    ;;
+o*)
+    [ -f "$urn" ] ||
+        die "File '$urn' doesn't exist"
+
+    { $age --decrypt -i "$basedir/identities" "$urn" | extract_tar; } &&
+        printf '%s\n' "File has been extracted into $PA_DIR"
+    ;;
+*) usage ;;
+esac


### PR DESCRIPTION
one of the commonly pointed out weaknesses of `pass`, which transfers to `pa`, is that it leaks metadata, i.e. the password names which usually refer to the services for which user stores their passwords are plain text, in contrast to something like keepass, where all of the entries are stored in a single encrypted database file. this can be a problem when using untrusted cloud to sync passwords. for `pass`, this is mitigated by an extension [pass-tomb](https://github.com/roddhjav/pass-tomb). it wraps around tomb, which is more than 3.5k lines of zsh I'll never comprehend. as an alternative, I came up with [urn](https://github.com/arcxio/urn/blob/main/urn), which is basically the same premise - creating encrypted containers from directories - but implemented ~100x simpler using tar + age and posix shell. the same concept can easily be integrated with pa, so I did. it works like this:

```
~/src/pa> pa a test
Generate a password? [y/N]: y
Saved 'test' to the store.
~/src/pa> pa s test
bPJk3VziuAbng9X1jN5sJJSaS1FL-Sv0Mv7MmcF5CoEQQgMO8y
~/src/pa> contrib/pa-urn
pa dir has been urned to /home/ar-1/.local/share/pa/passwords.urn
~/src/pa> pa s test
error: Password 'test' doesn't exist.
~/src/pa> pa l
~/src/pa> contrib/pa-urn
urn has been opened into /home/ar-1/.local/share/pa/passwords
~/src/pa> pa s test
bPJk3VziuAbng9X1jN5sJJSaS1FL-Sv0Mv7MmcF5CoEQQgMO8y
```