### PR TITLE
fix: Add mkdir -p to pw_edit function

### DIFF
--- a/pa
+++ b/pa
@@ -73,6 +73,8 @@ pw_edit() {
     ${EDITOR:-vi} "$tmpfile"
 
     [ -f "$tmpfile" ] && {
+        mkdir -p "$(dirname "./$name")" ||
+            die "Couldn't create category '$(dirname "./$name" | cut -c3-)'"
         $age --encrypt -R "$recipients_file" -o "./$name.age" "$tmpfile" ||
             die "Couldn't encrypt $name.age"
 


### PR DESCRIPTION
This patch fixes a failure for `pa edit my/new/category/item`.

Without this patch, pa does not create the category. Age fails with "file does not exist". This is puzzling, since `pa add` behaves differently.